### PR TITLE
fix: itinerary schema images field missing

### DIFF
--- a/entertainment/src/database/models/Itinerary.ts
+++ b/entertainment/src/database/models/Itinerary.ts
@@ -29,6 +29,7 @@ const itinerarySchema = new mongoose.Schema<IItinerary>({
   name: { type: String, required: true },
   description: { type: String, required: true },
   activities: { type: [String], required: true },
+  images: { type: [String], required: true },
   locations: {
     type: [
       {


### PR DESCRIPTION
Fixed the problem where the `images` field couldn't be retrieved