### PR TITLE
Client-feat: add FlightCard for flight selection

### DIFF
--- a/client/src/features/home/components/FlightCard.tsx
+++ b/client/src/features/home/components/FlightCard.tsx
@@ -1,0 +1,61 @@
+import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import FlightCardRoute from "./FlightCardRoute"
+
+interface FlightCardProps {
+  airline: string
+  departureTime: string
+  departureCode: string
+  arrivalTime: string
+  arrivalCode: string
+  price: number
+  isOneWay: boolean
+  returnDepartureTime?: string
+  returnDepartureCode?: string
+  returnArrivalTime?: string
+  returnArrivalCode?: string
+  currency?: string
+  onSelect?: () => void
+}
+
+export default function FlightCard(props: FlightCardProps) {
+  return (
+    <Card className="w-full max-w-2xl p-4 flex items-center justify-between gap-4">
+      <div className="flex items-center gap-8">
+        <div className="font-semibold text-lg text-primary">{props.airline}</div>
+        <div className="flex flex-col gap-3">
+        
+        <FlightCardRoute 
+          departureTime={props.departureTime}
+          departureCode={props.departureCode}
+          arrivalTime={props.arrivalTime}
+          arrivalCode={props.arrivalCode}
+        />
+
+        {!props.isOneWay && (
+          <FlightCardRoute
+            departureTime={props.returnDepartureTime || ""}
+            departureCode={props.returnDepartureCode || ""}
+            arrivalTime={props.returnArrivalTime || ""}
+            arrivalCode={props.returnArrivalCode || ""}
+          />)
+        }
+
+        </div>
+      </div>
+      <div className="flex flex-col items-center gap-4">
+        <div className="text-right">
+          <div className="text-lg font-semibold whitespace-nowrap">
+            {props.currency} {props.price.toLocaleString()}
+          </div>
+        </div>
+        <Button
+          onClick={props.onSelect}
+          className="bg-[#E6B954] hover:bg-[#d4a83d] text-black"
+        >
+          Select
+        </Button>
+      </div>
+    </Card>
+  )
+}

--- a/client/src/features/home/components/FlightCardRoute.tsx
+++ b/client/src/features/home/components/FlightCardRoute.tsx
@@ -1,0 +1,30 @@
+import { Plane } from "lucide-react"
+
+interface FlightCardRouteProps {
+  departureTime: string
+  departureCode: string
+  arrivalTime: string
+  arrivalCode: string
+}
+
+export default function FlightCardRoute(props: FlightCardRouteProps) {
+  return (
+    <>
+      <div className="flex items-center gap-3">
+           <div className="flex flex-col items-center">
+            <span className="text-2xl font-semibold">{props.departureTime}</span>
+            <span className="text-sm text-muted-foreground">{props.departureCode}</span>
+          </div>
+          <div className="flex items-center gap-2 w-32 md:w-48">
+            <div className="h-[1px] flex-1 bg-muted-foreground/30" />
+            <Plane className="size-4 text-muted-foreground rotate-45 -translate-y-[1px]" />
+          </div>
+          
+          <div className="flex flex-col items-center">
+            <span className="text-2xl font-semibold">{props.arrivalTime}</span>
+            <span className="text-sm text-muted-foreground">{props.arrivalCode}</span>
+          </div>
+        </div>
+    </>
+  )
+}


### PR DESCRIPTION
kept the carriar logo as string for now, will turn into logo in the future

One way
![Screenshot from 2024-11-06 22-58-56](https://github.com/user-attachments/assets/5f0b45be-8083-41ff-b01c-0f36b3b06b26)

2-way
![Screenshot from 2024-11-06 22-58-26](https://github.com/user-attachments/assets/4ba5b712-f83c-4703-a3ce-df3845e13c0f)
