### PR TITLE
Orders schema refactor: auto add timestamps

### DIFF
--- a/order/src/database/models/Order.ts
+++ b/order/src/database/models/Order.ts
@@ -27,7 +27,6 @@ export interface IItem {
 export interface IOrder {
   _id: Types.ObjectId;
   userId: string;
-  orderDate: Date;
   orderStatus: OrderStatus;
   paymentMethod: PaymentMethod;
   items: IItem[];
@@ -37,33 +36,41 @@ export interface IOrder {
   discountAmount?: number;
   billingAddress?: string;
   shippingAddress: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
-const orderSchema = new Schema<IOrder>({
-  userId: { type: String, required: true },
-  orderDate: { type: Date, required: true },
-  orderStatus: { type: String, enum: Object.values(OrderStatus), default: OrderStatus.processing },
-  paymentMethod: { type: String, required: true, enum: Object.values(PaymentMethod) },
-  items: {
-    type: [
-      {
-        name: String,
-        price: Number,
-        quantity: Number,
-        seller: String,
-        picture: String,
-        productId: String,
-      },
-    ],
-    required: true,
+const orderSchema = new Schema<IOrder>(
+  {
+    userId: { type: String, required: true },
+    orderStatus: {
+      type: String,
+      enum: Object.values(OrderStatus),
+      default: OrderStatus.processing,
+    },
+    paymentMethod: { type: String, required: true, enum: Object.values(PaymentMethod) },
+    items: {
+      type: [
+        {
+          name: String,
+          price: Number,
+          quantity: Number,
+          seller: String,
+          picture: String,
+          productId: String,
+        },
+      ],
+      required: true,
+    },
+    totalPrice: { type: Number, required: true },
+    totalQuantity: { type: Number, required: true },
+    promoCode: { type: String },
+    discountAmount: { type: Number },
+    billingAddress: { type: String },
+    shippingAddress: { type: String, required: true },
   },
-  totalPrice: { type: Number, required: true },
-  totalQuantity: { type: Number, required: true },
-  promoCode: { type: String },
-  discountAmount: { type: Number },
-  billingAddress: { type: String },
-  shippingAddress: { type: String, required: true },
-});
+  { timestamps: true },
+);
 
 const Order = model<IOrder>("Order", orderSchema);
 

--- a/order/src/database/repositories/order-repository.ts
+++ b/order/src/database/repositories/order-repository.ts
@@ -47,6 +47,6 @@ export async function deleteOrder(id: string) {
 
 // Get orders by date range
 export async function getOrdersByDateRange(startDate: Date, endDate: Date) {
-  return Order.find({ orderDate: { $gte: startDate, $lte: endDate } }).exec();
+  return Order.find({ createdAt: { $gte: startDate, $lte: endDate } }).exec();
 }
 


### PR DESCRIPTION
* Mongo automatically adds timestamp instead of relying on date sent from user
* This was primarily done to avoid multiple time zones issue and just fix the date to be based on the server clock itself