### PR TITLE
fix: change rating display to 2 decimal places

### DIFF
--- a/client/src/features/home/components/ProductCard.tsx
+++ b/client/src/features/home/components/ProductCard.tsx
@@ -48,7 +48,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
             {/* rating goes here */}
             <IoMdStar style={{ fontSize: "0.8rem" }} />
 
-            <p>{rating?.toPrecision(2)}</p>
+            <p>{rating?.toFixed(2)}</p>
           </div>
           <div className={CardStyles["product-card-container__language-time"]}>
             {/* language and opening time and availability goes here */}


### PR DESCRIPTION
fix the rating display to solve this issue

![d3bebf45-50e8-4c4b-9610-efd202294fea](https://github.com/user-attachments/assets/4a1195f0-8299-4646-8184-d433b11df2d6)
