### PR TITLE
Add `rating` field to booking schema

### DIFF
--- a/api-gateway/src/utils/types.ts
+++ b/api-gateway/src/utils/types.ts
@@ -45,7 +45,8 @@ export interface IBooking {
   status?: bookingStatus;
   selectedPrice?: number;
   selectedDate?: Date;
-  isRated?: number;
+  rating?: number;
+  itineraryTourGuideRating?: number;
 }
 
 export interface PopulatedBooking {
@@ -56,7 +57,8 @@ export interface PopulatedBooking {
   status: bookingStatus;
   selectedPrice: number;
   selectedDate?: Date;
-  isRated?: number;
+  rating?: number;
+  itineraryTourGuideRating?: number;
 }
 
 export interface IItinerary {

--- a/booking/src/database/models/Booking.ts
+++ b/booking/src/database/models/Booking.ts
@@ -31,6 +31,10 @@ const bookingSchema = new mongoose.Schema({
     type: Number,
     default: 0,
   },
+  itineraryTourGuideRating: {
+    type: Number,
+    default: 0,
+  },
 });
 
 export default mongoose.model("Booking", bookingSchema);

--- a/booking/src/utils/types.ts
+++ b/booking/src/utils/types.ts
@@ -19,5 +19,6 @@ export interface IBooking {
   status?: bookingStatus;
   selectedPrice?: number;
   selectedDate?: Date;
-  isRated?: number;
+  rating?: number;
+  itineraryTourGuideRating?: number;
 }

--- a/client/src/features/home/types/home-page-types.d.ts
+++ b/client/src/features/home/types/home-page-types.d.ts
@@ -49,7 +49,8 @@ export interface IBooking {
   status?: TBookingStatus;
   selectedPrice?: number;
   selectedDate?: Date;
-  isRated?: number;
+  rating?: number;
+  itineraryTourGuideRating?: number;
 }
 
 export type TPopulatedBooking = {
@@ -60,7 +61,8 @@ export type TPopulatedBooking = {
   status: TBookingStatus;
   selectedPrice: number;
   selectedDate: Date;
-  isRated?: number;
+  rating?: number;
+  itineraryTourGuideRating?: number;
 };
 
 export type TBookingType = {
@@ -70,6 +72,8 @@ export type TBookingType = {
   status?: TBookingStatus;
   selectedPrice?: number;
   selectedDate?: Date;
+  rating?: number;
+  itineraryTourGuideRating?: number;
 };
 
 interface CancellationRule {


### PR DESCRIPTION
The reason for this is to avoid having the user be able to rate the *same* activity/itinerary multiple times. 

There was also another way which is contacting the entertainment service to see if the user rated this event before or not. However, I believe that adding the `isRated` flag allows us to reduce the number of requests sent. 

Let me know what you think...