### PR TITLE
Bug fix/login logout conditions in navigation for historical places

### DIFF
--- a/client/src/app/App.tsx
+++ b/client/src/app/App.tsx
@@ -78,7 +78,8 @@ export default function App() {
             </Route>
             <Route path="/signup" element={<SignupSelector />} />
             <Route path="/signin" element={<Login />} />
-            <Route path="/details/:id" element={<DetailsPage />} />
+            <Route path="/details/:placeid/:id" element={<DetailsPage />} />
+            <Route path="/details/:placeid/" element={<DetailsPage />} />
             <Route element={<SettingsView />}>
               <Route path="/user-settings/:id" element={<ProfileForm />} />
               <Route path="/user-settings/account/:id" element={<AccountForm />} />

--- a/client/src/features/home/components/DetailsPage.tsx
+++ b/client/src/features/home/components/DetailsPage.tsx
@@ -1,6 +1,6 @@
 import DetailsPageStyles from "../styles/DetailsPage.module.css";
 import aswan from "@/assets/Aswan.webp";
-import { useLocation } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import { FaTags } from "react-icons/fa6";
 import { IoMdStar } from "react-icons/io";
 import { CiGlobe } from "react-icons/ci";
@@ -12,6 +12,7 @@ import currencyExchange from "@/utils/currency-exchange";
 
 const DetailsPage = () => {
   const location = useLocation();
+  const {id, placeid} = useParams();
   const { item }: { item: any } = location.state || {}; // Access the passed item through state
 
   const getAverageRating = (ratings?: number[]) => {
@@ -34,7 +35,7 @@ const DetailsPage = () => {
 
   return (
     <div className={DetailsPageStyles["full-page-container"]}>
-      <TouristHomePageNavigation loggedIn={true} />
+      <TouristHomePageNavigation loggedIn={id?true:false} />
       <div className={DetailsPageStyles["details-page-content-container"]}>
         <div className={DetailsPageStyles["item-details"]}>
           {/* details goes here */}

--- a/client/src/features/home/components/GeneralGridView.tsx
+++ b/client/src/features/home/components/GeneralGridView.tsx
@@ -120,7 +120,7 @@ function GeneralGridView() {
     const type =
       "languages" in item ? "itinerary" : "isBookingOpen" in item ? "activity" : "historicalPlace";
     if (type === "historicalPlace") {
-      navigate(`/details/${item._id}`, { state: { item } });
+      navigate(`/details/${item._id}/${id?id:""}`, { state: { item } });
       return;
     }
     navigate(`/my-trips-details?userId=${id}&eventId=${item._id}&bookingId=null&type=${type}`, {


### PR DESCRIPTION
This is a temporary solution until we use authentication

it fixed the issue were when i am a guest and view details page of historical place, it shoes the avatar and currency as if i am logged in 


<img width="1440" alt="Screenshot 2024-11-10 at 1 11 41 AM" src="https://github.com/user-attachments/assets/572058bb-eed1-4886-b8bf-ae3eb02afd25">
