### PR TITLE
Remove product bugged default rating

### DIFF
--- a/client/src/api-calls/products-api-calls.ts
+++ b/client/src/api-calls/products-api-calls.ts
@@ -29,7 +29,6 @@ export async function createProduct(
   newProductData.picture = "placeholder"; // TODO: Change this to Rahhal logo
   newProductData.seller = userId;
   newProductData.sellerName = userName;
-  newProductData.ratings = [{ rating: Math.floor(Math.random() * 5) + 1, userId: userId }];
   const response = await axios.post(SERVICES_URLS.PRODUCT + "/products", newProductData);
   const productId = (response.data as TProduct)._id;
 
@@ -57,8 +56,6 @@ export async function updateProduct(productData: TProduct, productImages: FileLi
   );
 
   productData.picture = urls[0];
-
-  
 
   await axios.patch(`${SERVICES_URLS.PRODUCT}/products/${productData!._id}`, productData);
   alert("Product updated successfully");


### PR DESCRIPTION
Remove the random default rating that was there for testing since sprint one. Rating now is not just a number and the schema has changes and that's why sending a number to the database cause an error that prevented the product from being created successfully