### PR TITLE
feat: added toast and managed state for when an activity or itinerary…

### DIFF
--- a/client/src/features/home/components/activities/BookedActivityDetails.tsx
+++ b/client/src/features/home/components/activities/BookedActivityDetails.tsx
@@ -114,7 +114,7 @@ const BookedActivityDetailsPage: React.FC<BookedActivityDetailsProps> = ({
     }
   }, []);
 
-  //to make sure that activity remains canceled if user used browser navigation to go back
+  // to make sure that activity remains canceled if user used browser navigation to go back
   React.useEffect(() => {
     const checkBookingStatus = async () => {
       try {
@@ -122,13 +122,14 @@ const BookedActivityDetailsPage: React.FC<BookedActivityDetailsProps> = ({
           const latestBooking = await fetchBookingById(booking._id);
           if (latestBooking.status === bookingStatus.Cancelled) {
             setIsButtonDisabled(true);
+            setBooking({ ...booking, status: bookingStatus.Cancelled });
           }
         }
       } catch (error) {
         console.log(error);
       }
     };
-  
+
     checkBookingStatus();
   }, []);
 

--- a/client/src/features/home/components/itineraries/BookedItineraryDetails.tsx
+++ b/client/src/features/home/components/itineraries/BookedItineraryDetails.tsx
@@ -77,7 +77,7 @@ const BookedItineraryDetailsPage: React.FC<BookedItineraryDetailsProps> = ({
     });
   }, [selectedDate]);
 
-  //to make sure that itinerary remains canceled if user used browser navigation to go back
+  // to make sure that itinerary remains canceled if user used browser navigation to go back
   useEffect(() => {
     const checkBookingStatus = async () => {
       try {
@@ -85,13 +85,14 @@ const BookedItineraryDetailsPage: React.FC<BookedItineraryDetailsProps> = ({
           const latestBooking = await fetchBookingById(booking._id);
           if (latestBooking.status === bookingStatus.Cancelled) {
             setIsButtonDisabled(true);
+            setBooking({ ...booking, status: bookingStatus.Cancelled });
           }
         }
       } catch (error) {
         console.log(error);
       }
     };
-  
+
     checkBookingStatus();
   }, []);
 


### PR DESCRIPTION
Req 62: View the amount from the cancelled event/ activity or itinerary in my wallet

1- Cancelled Button now becomes disabled as soon as cancel booking is done
2- Toast to indicate value of Refund
3- Handled state management so that browser navigation does not allow multiple refunds to the same canceled booking

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/558c63b1-32aa-42ad-9699-8106f053e886">
